### PR TITLE
Primary default config path as XDG Base Dir Standard, more options for setting the config path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The idea behind `pier` is to create a central repository for all your scripts, a
 See `src/cli.yml` for a more detailed spec.
 
 ```
-pier 0.2.0
+pier 0.2.1
+Benjamin Scholtz <bscholtz.bds@gmail.com>
 A simple Docker script management CLI
 
 USAGE:
@@ -29,7 +30,13 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -c, --config <FILE>    sets a custom config file (default "$HOME/.pier")
+    -c, --config <FILE>    Sets a custom config file.
+                           
+                           DEFAULT PATH is otherwise determined in this order:
+                           1. "$PIER_CONFIG_PATH"
+                           2. "$XDG_CONFIG_HOME/pier/config"
+                           3. "$HOME/.config/pier/config"
+                           4. "$HOME/.pier")
 
 ARGS:
     <INPUT>    alias/name for script to run
@@ -41,6 +48,8 @@ SUBCOMMANDS:
     remove    Remove a script using alias
     run       Run script
 ```
+
+`pier list`, `pier add "ip link set wlp58s0 down && sleep 5 && ip link set wlp58s0 up" --alias refresh-wifi`, `pier refresh-wifi`
 
 ## Example `pier` TOML config
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,5 +1,5 @@
 name: pier
-version: "0.2.0"
+version: "0.2.1"
 author: Benjamin Scholtz <bscholtz.bds@gmail.com>
 about: A simple Docker script management CLI
 args:
@@ -11,7 +11,14 @@ args:
         short: c
         long: config
         value_name: FILE
-        help: sets a custom config file (default "$HOME/.pier")
+        long_help: |
+            Sets a custom config file.
+
+            DEFAULT PATH is otherwise determined in this order:
+            1. "$PIER_CONFIG_PATH"
+            2. "$XDG_CONFIG_HOME/pier/config"
+            3. "$HOME/.config/pier/config"
+            4. "$HOME/.pier")
         takes_value: true
     # - accept:
     #     short: y


### PR DESCRIPTION
Hi,

Would be really nice with more options on where the default config file is stored, generally the home directory is so overcrowded so many prefer to use the XDG standard instead. 

I made an implementation of this so it uses the XDG standard as primary default path, but with $HOME/.pier as fallback in case $XDG/pier/config doesn't exist. Also added an option to set the config path to something entirely different using an environment variable $PIER_CONFIG_PATH. 

Maybe you could have a look at the code and see if you think this would be a good solution for this problem?