### PR TITLE
Crates update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "pier"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pier"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "Benjamin Scholtz <bscholtz.bds@gmail.com>",
     "Isak Johansson"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Using **Nix** package manager:
 See `src/cli.yml` for a more detailed spec.
 
 ```
-pier 0.2.3
+pier 0.1.2
 Benjamin Scholtz
 A simple Docker script management CLI
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,5 +1,5 @@
 name: pier
-version: "0.2.3"
+version: "0.1.2"
 author: Benjamin Scholtz
 about: A simple Docker script management CLI
 settings:


### PR DESCRIPTION
The GitHub tagged/released package versions and Crates package version are out of sync. Will correct on next Crates release.