### PR TITLE
ADDED better formatting for commands, by default it now only shows the...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "pier"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pier"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     "Benjamin Scholtz",
     "Isak Johansson"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Using **Nix** package manager:
 See `src/cli.yml` for a more detailed spec.
 
 ```
-pier 0.1.3
+pier 0.1.4
 Benjamin Scholtz, Isak Johansson
 A simple script management CLI
 
@@ -89,7 +89,6 @@ SUBCOMMANDS:
     remove    alias: rm - Remove a script matching alias.
     run       Run a script matching alias.
     show      Show a script matching alias.
-
 ```
 
 `pier list`, `pier add "ip link set wlp58s0 down && sleep 5 && ip link set wlp58s0 up" --alias refresh-wifi`, `pier refresh-wifi`

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,16 @@ fn handle_subcommands(cli: Cli) -> Result<()> {
                 let script = config.fetch_script(&alias)?;
                 println!("{}", script.command);
             }
-            CliSubcommand::List { list_aliases, tags } => match list_aliases {
+            CliSubcommand::List {
+                list_aliases,
+                tags,
+                list_full_command,
+                command_display_width,
+            } => match list_aliases {
                 true => config.list_aliases(tags)?,
-                false => config.list_scripts(tags)?,
+                false => config
+                    .set_command_display_width(command_display_width, list_full_command)
+                    .list_scripts(tags)?,
             },
             CliSubcommand::Run { alias } => {
                 let arg = "";

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -26,6 +26,24 @@ pier_test!(cli => test_list_scripts, cfg => CONFIG_1,
         .success();
 });
 
+// Tests listing alias
+pier_test!(cli => test_list_alias_scripts, cfg => CONFIG_1,
+| _cfg: ChildPath, mut cmd: Command | {
+    // TODO Add some way to verify the output other than exit code.
+    cmd.arg("ls");
+    cmd.assert()
+        .success();
+});
+
+// Tests listing all scripts
+pier_test!(cli => test_list_scripts_with_command_width, cfg => CONFIG_1,
+| _cfg: ChildPath, mut cmd: Command | {
+    // TODO Add some way to verify the output other than exit code.
+    cmd.args(&["list", "-c", "20"]);
+    cmd.assert()
+        .success();
+});
+
 // Tests listing all aliases
 pier_test!(cli => test_list_aliases, cfg => CONFIG_1,
 | _cfg: ChildPath, mut cmd: Command | {

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -19,7 +19,9 @@ pier_test!(lib => test_error_no_scripts_exists, cfg => r#""#,
 | _cfg: ChildPath, mut lib: Config | {
     err_eq!(lib.remove_script(""), NoScriptsExists);
     err_eq!(lib.fetch_script(""), NoScriptsExists);
-    err_eq!(lib.list_scripts(None), NoScriptsExists);
+    err_eq!(lib
+        .set_command_display_width(None, true)
+        .list_scripts(None), NoScriptsExists);
 });
 
 // Tests that it returns the error ConfigRead if the file cannot be read.
@@ -39,7 +41,7 @@ pier_test!(basic => test_config_write_error, | _te: TestEnv | {
 
 // Tests that it returns the error TomlParse if the config is not valid Toml
 pier_test!(basic => test_toml_parse_error, | te: TestEnv| {
-    let cfg = te.dir.child("pier_config"); 
+    let cfg = te.dir.child("pier_config");
     cfg.touch().expect("Unable to create file");
     cfg.write_str(trim!(r#"
         [scripts.test_cmd_1]


### PR DESCRIPTION
first line and only 120 characters long.
To show the whole command in the table use the cli option -l.